### PR TITLE
Throw error object instead of string

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,5 +68,5 @@ module.exports = async (stimulus, context = [], language) => {
         }
     }
 
-    throw "Failed to get a response after 15 tries";
+    throw new Error("Failed to get a response after 15 tries.");
 };


### PR DESCRIPTION
Throwing a string instead of an actual Error object makes error handling difficult and type-unsafe. If the method throws an error, it's hard to know whether to treat it as a string or an object, because `superagent` throws Errors objects. Strings also lack a stacktrace, which makes debugging harder.

See [here](https://stackoverflow.com/a/11512623) for more info on why throwing Error objects is preferred.

Since this change could affect the error handling of any project using this package (mine included), maybe release it as a minor version change (1.2) instead of just a patch?